### PR TITLE
Remove spurious `exception` logging

### DIFF
--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -526,8 +526,6 @@ class AuthnResponse(StatusResponse):
                 try:
                     if not self.check_subject_confirmation_in_response_to(
                             self.in_response_to):
-                        logger.exception(
-                            "Unsolicited response %s" % self.in_response_to)
                         raise UnsolicitedResponse(
                             "Unsolicited response: %s" % self.in_response_to)
                 except AttributeError:
@@ -536,8 +534,6 @@ class AuthnResponse(StatusResponse):
                 # Should check that I haven't seen this before
                 pass
             else:
-                logger.exception(
-                    "Unsolicited response %s" % self.in_response_to)
                 raise UnsolicitedResponse(
                     "Unsolicited response: %s" % self.in_response_to)
 


### PR DESCRIPTION
These two `logger.exception` calls are both incorrect, because neither are in an `except` block - which means that they will log a stacktrace for whatever the most recent exception was (which may be wholly unrelated).

They could be changed to `logger.error`, but since this exception will also be logged at `saml2.client_base:718` as well as propagating the exception to application code, I don't think there is any need to log anything here at all.


### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?